### PR TITLE
Fix adressing relative paths + comment non-existing files

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,29 +3,30 @@
   <head>
     <title>Ивентіще: події та свята з душею</title>
     <link rel="stylesheet" href="css/bootstrap.css">
-    <link rel="stylesheet" href="..js/onepage-scroll-master/onepage-scroll.css">
+    <link rel="stylesheet" href="js/onepage-scroll-master/onepage-scroll.css">
   
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="css/bootstrap-responsive.css" rel="stylesheet">
+    <!-- Такого файла нет - стоит добавить, возможно? -->
+    <!-- <link href="css/bootstrap-responsive.css" rel="stylesheet"> -->
    
     <meta charset="utf-8"> 
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
      
-   <link rel="stylesheet" type="text/css" href="../js/fullPage.js-master/jquery.fullPage.css" />
+   <link rel="stylesheet" type="text/css" href="js/fullPage.js-master/jquery.fullPage.css" />
 
   <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 
 <!-- This following line is needed in case of using the default easing option or when using another
  one rather than "linear" or "swing". You can also add the full jQuery UI instead of this file if you prefer -->
-  <script src="../js/fullPage.js-master/vendors/jquery.easings.min.js"></script>
+  <script src="js/fullPage.js-master/vendors/jquery.easings.min.js"></script>
 
 
 <!-- This following line needed in the case of using the plugin option `scrollOverflow:true` -->
-  <script type="text/javascript" src="../js/fullPage.js-master/vendors/jquery.slimscroll.min.js"></script>
+  <script type="text/javascript" src="js/fullPage.js-master/vendors/jquery.slimscroll.min.js"></script>
 
-  <script type="text/javascript" src="../js/fullPage.js-master/jquery.fullPage.js"></script>
-
-    <script type="text/javascript" src="../js/stellar.js-master/jquery.stellar.min.js"></script>
+  <script type="text/javascript" src="js/fullPage.js-master/jquery.fullPage.js"></script>
+    <!-- Такой папки нет - стоит добавить, возможно? -->
+    <!-- <script type="text/javascript" src="js/stellar.js-master/jquery.stellar.min.js"></script> -->
 
    
 


### PR DESCRIPTION
1) change '..js' to 'js' paths - they will be taken relatively to location of index.html (previous version meant going one folder up and looking for files there in js folder which resulted in 404)
2) comment out files that are 404 and not in corresponding folders - possibly might need to remove those altogether or add to the repo